### PR TITLE
add concurrency support to the Java HTTP transport (#122)

### DIFF
--- a/java/itara-integration-tests/src/test/java/io/itara/integration/HttpTransportConcurrencyIntegrationTest.java
+++ b/java/itara-integration-tests/src/test/java/io/itara/integration/HttpTransportConcurrencyIntegrationTest.java
@@ -1,0 +1,201 @@
+package io.itara.integration;
+
+import io.itara.runtime.DispatchHandler;
+import io.itara.spi.transport.TransportConfig;
+import io.itara.transport.http.HttpTransportConfig;
+import io.itara.transport.http.HttpTransportFactory;
+import io.itara.transport.http.ItaraHttpServer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Concurrency integration tests for the HTTP transport server.
+ *
+ * Verifies that ItaraHttpServer handles concurrent inbound requests in
+ * parallel rather than serially on a single thread (issue #122).
+ *
+ * The dispatcher blocks every request on a shared latch until all requests
+ * have arrived. A serial server would never have more than one request in
+ * flight, so the latch would never open and the requests would fail —
+ * no timing-based assertions needed.
+ *
+ * No Docker required — pure localhost socket communication.
+ */
+@DisplayName("HTTP Transport Concurrency")
+class HttpTransportConcurrencyIntegrationTest {
+
+    private static final String COMPONENT_ID = "concurrent-component";
+    private static final int CONCURRENT_REQUESTS = 4;
+
+    @Test
+    @DisplayName("concurrent requests are handled in parallel on distinct threads")
+    void concurrentRequestsHandledInParallel() throws Exception {
+        int port = findFreePort();
+
+        CountDownLatch allInFlight = new CountDownLatch(CONCURRENT_REQUESTS);
+        Set<String> handlerThreads = ConcurrentHashMap.newKeySet();
+
+        DispatchHandler blockingDispatcher = (componentId, methodName, requestBytes, headers) -> {
+            handlerThreads.add(Thread.currentThread().getName());
+            allInFlight.countDown();
+            if (!allInFlight.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Requests were not handled in parallel");
+            }
+            return "ok".getBytes(StandardCharsets.UTF_8);
+        };
+
+        ItaraHttpServer server = new ItaraHttpServer(
+                port, Map.of(COMPONENT_ID, blockingDispatcher));
+        server.start();
+        try {
+            List<Integer> statuses = fireConcurrentRequests(port, CONCURRENT_REQUESTS);
+
+            for (int status : statuses) {
+                assertEquals(200, status, "Every concurrent request must succeed");
+            }
+            assertEquals(0, allInFlight.getCount(),
+                    "All " + CONCURRENT_REQUESTS + " requests must be in flight simultaneously");
+            assertTrue(handlerThreads.size() > 1,
+                    "Concurrent requests must be handled on more than one thread, saw: "
+                            + handlerThreads);
+        } finally {
+            server.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("explicitly configured pool size still serves that many requests in parallel")
+    void configuredPoolSizeHandlesThatManyInParallel() throws Exception {
+        int port = findFreePort();
+        int poolSize = 2;
+
+        CountDownLatch bothInFlight = new CountDownLatch(poolSize);
+        DispatchHandler blockingDispatcher = (componentId, methodName, requestBytes, headers) -> {
+            bothInFlight.countDown();
+            if (!bothInFlight.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Requests were not handled in parallel");
+            }
+            return "ok".getBytes(StandardCharsets.UTF_8);
+        };
+
+        ItaraHttpServer server = new ItaraHttpServer(
+                port, Map.of(COMPONENT_ID, blockingDispatcher), poolSize);
+        server.start();
+        try {
+            List<Integer> statuses = fireConcurrentRequests(port, poolSize);
+            for (int status : statuses) {
+                assertEquals(200, status);
+            }
+        } finally {
+            server.stop();
+        }
+    }
+
+    // ── Config parsing ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("threadPoolSize config parsing")
+    class ThreadPoolSizeParsing {
+
+        private final HttpTransportFactory factory = new HttpTransportFactory();
+
+        private HttpTransportConfig parse(Map<String, String> params) throws Exception {
+            return (HttpTransportConfig) factory.parseConfig(
+                    TransportConfig.builder().params(params).build());
+        }
+
+        @Test
+        @DisplayName("defaults when threadPoolSize is absent")
+        void defaultsWhenAbsent() throws Exception {
+            HttpTransportConfig config = parse(Map.of("port", "8080"));
+            assertEquals(HttpTransportConfig.DEFAULT_THREAD_POOL_SIZE,
+                    config.getThreadPoolSize());
+        }
+
+        @Test
+        @DisplayName("parses an explicit threadPoolSize")
+        void parsesExplicitValue() throws Exception {
+            HttpTransportConfig config = parse(
+                    Map.of("port", "8080", "threadPoolSize", "32"));
+            assertEquals(32, config.getThreadPoolSize());
+        }
+
+        @Test
+        @DisplayName("rejects a non-integer threadPoolSize")
+        void rejectsNonInteger() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> parse(Map.of("port", "8080", "threadPoolSize", "many")));
+        }
+
+        @Test
+        @DisplayName("rejects a non-positive threadPoolSize")
+        void rejectsNonPositive() {
+            assertThrows(IllegalArgumentException.class,
+                    () -> parse(Map.of("port", "8080", "threadPoolSize", "0")));
+        }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────
+
+    private static List<Integer> fireConcurrentRequests(int port, int count) throws Exception {
+        ExecutorService clients = Executors.newFixedThreadPool(count);
+        try {
+            List<Future<Integer>> inFlight = new ArrayList<>();
+            for (int i = 0; i < count; i++) {
+                inFlight.add(clients.submit(() -> post(port)));
+            }
+            List<Integer> statuses = new ArrayList<>();
+            for (Future<Integer> response : inFlight) {
+                statuses.add(response.get(30, TimeUnit.SECONDS));
+            }
+            return statuses;
+        } finally {
+            clients.shutdownNow();
+        }
+    }
+
+    private static int post(int port) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(
+                "http://localhost:" + port + "/itara/" + COMPONENT_ID + "/work")
+                .openConnection();
+        connection.setRequestMethod("POST");
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(5_000);
+        connection.setReadTimeout(30_000);
+        try (OutputStream out = connection.getOutputStream()) {
+            out.write("payload".getBytes(StandardCharsets.UTF_8));
+        }
+        int status = connection.getResponseCode();
+        connection.disconnect();
+        return status;
+    }
+
+    private static int findFreePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransport.java
+++ b/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransport.java
@@ -39,11 +39,13 @@ public class HttpTransport implements ItaraTransport {
     private final Map<String, DispatchHandler> dispatchers = new ConcurrentHashMap<>();
 
     private final int port;
+    private final int threadPoolSize;
 
     private ItaraHttpServer activeServer;
 
     public HttpTransport(HttpTransportConfig config) {
         this.port = config.getPort();
+        this.threadPoolSize = config.getThreadPoolSize();
     }
 
     @Override
@@ -131,8 +133,9 @@ public class HttpTransport implements ItaraTransport {
     public void start() throws Exception {
         if (dispatchers.isEmpty()) return;
         log.fine("[Itara/HTTP] starting server on port " + port
-                + " with " + dispatchers.size() + " registered component(s)");
-        activeServer = new ItaraHttpServer(port, dispatchers);
+                + " with " + dispatchers.size() + " registered component(s)"
+                + " and a thread pool of " + threadPoolSize);
+        activeServer = new ItaraHttpServer(port, dispatchers, threadPoolSize);
         activeServer.start();
     }
 

--- a/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransportConfig.java
+++ b/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransportConfig.java
@@ -10,26 +10,40 @@ import io.itara.spi.transport.ItaraTransportGroupingKey;
  * connections that share a port share one HttpTransport instance,
  * regardless of host (which is outbound-only and irrelevant for grouping).
  *
- * host          — remote host for outbound calls. Null for inbound-only connections.
- * port          — port number. Required. Used as the grouping key.
- * handleTimeout — whether to enforce the per-call timeout natively via the
- *                 HTTP client's connect/read timeout settings.
+ * host           — remote host for outbound calls. Null for inbound-only connections.
+ * port           — port number. Required. Used as the grouping key.
+ * handleTimeout  — whether to enforce the per-call timeout natively via the
+ *                  HTTP client's connect/read timeout settings.
+ * threadPoolSize — number of threads the inbound server uses to handle
+ *                  requests concurrently. Inbound-only; does not affect
+ *                  grouping, so the config that first creates the transport
+ *                  instance for a port determines the pool size.
  */
 public final class HttpTransportConfig implements ItaraTransportConfig, ItaraTransportGroupingKey {
+
+    /** Default inbound server thread pool size when 'threadPoolSize' is not configured. */
+    public static final int DEFAULT_THREAD_POOL_SIZE = 10;
 
     private final String host;
     private final int port;
     private final boolean handleTimeout;
+    private final int threadPoolSize;
 
     public HttpTransportConfig(String host, int port, boolean handleTimeout) {
+        this(host, port, handleTimeout, DEFAULT_THREAD_POOL_SIZE);
+    }
+
+    public HttpTransportConfig(String host, int port, boolean handleTimeout, int threadPoolSize) {
         this.host = host;
         this.port = port;
         this.handleTimeout = handleTimeout;
+        this.threadPoolSize = threadPoolSize;
     }
 
     public String getHost()          { return host; }
     public int getPort()             { return port; }
     public boolean isHandleTimeout() { return handleTimeout; }
+    public int getThreadPoolSize()   { return threadPoolSize; }
 
     @Override
     public ItaraTransportGroupingKey groupingKey() {

--- a/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransportFactory.java
+++ b/java/itara-transport-http/src/main/java/io/itara/transport/http/HttpTransportFactory.java
@@ -13,8 +13,11 @@ import io.itara.spi.transport.TransportConfig;
  * instances on demand.
  *
  * Expected params:
- *   port  — required for both inbound and outbound connections
- *   host  — required for outbound connections, ignored for inbound
+ *   port           — required for both inbound and outbound connections
+ *   host           — required for outbound connections, ignored for inbound
+ *   threadPoolSize — optional; number of threads the inbound server uses to
+ *                    handle requests concurrently. Defaults to
+ *                    HttpTransportConfig.DEFAULT_THREAD_POOL_SIZE.
  */
 public class HttpTransportFactory implements ItaraTransportFactory {
 
@@ -39,7 +42,25 @@ public class HttpTransportFactory implements ItaraTransportFactory {
         }
 
         String host = config.getParams().get("host");
-        return new HttpTransportConfig(host, port, config.isHandleTimeout());
+
+        int threadPoolSize = HttpTransportConfig.DEFAULT_THREAD_POOL_SIZE;
+        String threadPoolSizeStr = config.getParams().get("threadPoolSize");
+        if (threadPoolSizeStr != null && !threadPoolSizeStr.isBlank()) {
+            try {
+                threadPoolSize = Integer.parseInt(threadPoolSizeStr.trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException(
+                        "[Itara/HTTP] Param 'threadPoolSize' must be an integer, got: '"
+                                + threadPoolSizeStr + "'");
+            }
+            if (threadPoolSize < 1) {
+                throw new IllegalArgumentException(
+                        "[Itara/HTTP] Param 'threadPoolSize' must be positive, got: "
+                                + threadPoolSize);
+            }
+        }
+
+        return new HttpTransportConfig(host, port, config.isHandleTimeout(), threadPoolSize);
     }
 
     @Override

--- a/java/itara-transport-http/src/main/java/io/itara/transport/http/ItaraHttpServer.java
+++ b/java/itara-transport-http/src/main/java/io/itara/transport/http/ItaraHttpServer.java
@@ -10,6 +10,10 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -40,12 +44,23 @@ public class ItaraHttpServer {
     private static final Logger log = Logger.getLogger(ItaraHttpServer.class.getName());
 
     private final HttpServer server;
+    private final ExecutorService executor;
     private final Map<String, DispatchHandler> dispatchers;
 
     public ItaraHttpServer(int port, Map<String, DispatchHandler> dispatchers) throws IOException {
+        this(port, dispatchers, HttpTransportConfig.DEFAULT_THREAD_POOL_SIZE);
+    }
+
+    public ItaraHttpServer(int port, Map<String, DispatchHandler> dispatchers,
+                           int threadPoolSize) throws IOException {
         this.dispatchers = dispatchers;
         this.server = HttpServer.create(new InetSocketAddress(port), 0);
         this.server.createContext("/itara/", this::handle);
+        // Without an explicit executor the JDK server handles all exchanges
+        // serially on a single internal thread — concurrent requests would
+        // queue behind each other.
+        this.executor = Executors.newFixedThreadPool(threadPoolSize, namedThreadFactory(port));
+        this.server.setExecutor(executor);
     }
 
     public void start() {
@@ -55,7 +70,14 @@ public class ItaraHttpServer {
 
     public void stop() {
         server.stop(1);
+        executor.shutdown();
         log.info("[Itara/HTTP] Server stopped");
+    }
+
+    private static ThreadFactory namedThreadFactory(int port) {
+        AtomicInteger counter = new AtomicInteger(1);
+        return runnable -> new Thread(runnable,
+                "itara-http-" + port + "-" + counter.getAndIncrement());
     }
 
     private void handle(HttpExchange exchange) throws IOException {


### PR DESCRIPTION
Fixes #122

The JDK HttpServer with no executor set handles all exchanges serially on a single internal thread, so concurrent requests queued behind each other. ItaraHttpServer now sets a fixed thread pool executor before start(), sized by the new optional 'threadPoolSize' transport param (default 10). Pool threads are named itara-http-{port}-{n} so parallel handling is visible in logs, and the pool is shut down on stop().

The pool size is inbound-only and does not affect grouping — the config that first creates the transport instance for a port wins.

Adds an integration test that blocks each request on a shared latch until all of them are in flight together, which only completes when the server handles requests in parallel, plus parsing tests for the new param.